### PR TITLE
Type declaration body 'sub'

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -143,7 +143,7 @@ module.exports = grammar({
         type_decl_body: $ => choice(
             $.unnbody,
             seq('(',$.fields,')'),
-            seq('-','(',$.fields,')'),
+            seq('sub','(',$.fields,')'),
             seq('new','(',$.fields,')'),
             seq($.fun_decl,'(',$.fields,$.maparrow,$.fields,')'),
         ),


### PR DESCRIPTION
Type declaration body has 'sub' keyword as a choice not minus sign.